### PR TITLE
Adding workspace and file URI to snippet code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Inside the code interpolation, you have access to a few special variables:
 Additionally, every variable defined in one code block will be available in all the subsequent code
 blocks in the snippet.
 
+The `require` function can also be used to import NodeJS modules.
+
 ## Examples
 
 - Simple snippet which greets you with the current date and time

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Inside the code interpolation, you have access to a few special variables:
   defined in the snippet block. You can use it to dynamically change the snippet content.
 - `m`: An array containing the match groups of your regular expression trigger, or an empty array if
   the trigger is not a regular expression.
+- `w`: A URI string of the currently opened workspace, or an empty string if no workspace is open.
+- `path`: A URI string of the current document. (untitled documents have the scheme `untitled`)
 
 Additionally, every variable defined in one code block will be available in all the subsequent code
 blocks in the snippet.
@@ -118,5 +120,13 @@ snippet box "Box" A
 ``rv = '┌' + '─'.repeat(t[0].length + 2) + '┐'``
 │ $1 │
 ``rv = '└' + '─'.repeat(t[0].length + 2) + '┘'``
+endsnippet
+```
+
+- Snippet to insert the current filename
+
+```hsnips
+snippet filename "Current Filename"
+``rv = require('path').basename(path)``
 endsnippet
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,65 +5,90 @@
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-            "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+            "version": "7.12.11",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+            "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.10.1"
+                "@babel/highlight": "^7.10.4"
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-            "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+            "version": "7.12.11",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-            "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                }
             }
         },
-        "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-            "dev": true
+        "@eslint/eslintrc": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
+            "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "debug": "^4.1.1",
+                "espree": "^7.3.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^3.13.1",
+                "lodash": "^4.17.19",
+                "minimatch": "^3.0.4",
+                "strip-json-comments": "^3.1.1"
+            }
         },
         "@types/node": {
-            "version": "10.14.19",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.19.tgz",
-            "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q==",
+            "version": "10.17.50",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
+            "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==",
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.38.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.38.0.tgz",
-            "integrity": "sha512-aGo8LQ4J1YF0T9ORuCO+bhQ5sGR1MXa7VOyOdEP685se3wyQWYUExcdiDi6rvaK61KUwfzzA19JRLDrUbDl7BQ==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+            "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
             "dev": true
         },
         "acorn": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-            "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
             "dev": true
         },
         "acorn-jsx": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-            "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
             "dev": true
         },
         "ajv": {
-            "version": "6.12.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-            "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
@@ -72,22 +97,11 @@
                 "uri-js": "^4.2.2"
             }
         },
-        "ansi-escapes": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-            "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.11.0"
-            },
-            "dependencies": {
-                "type-fest": {
-                    "version": "0.11.0",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-                    "dev": true
-                }
-            }
+        "ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "dev": true
         },
         "ansi-regex": {
             "version": "5.0.0",
@@ -114,9 +128,9 @@
             }
         },
         "astral-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
         },
         "balanced-match": {
@@ -142,36 +156,55 @@
             "dev": true
         },
         "chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
-        },
-        "chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "dev": true
-        },
-        "cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dev": true,
-            "requires": {
-                "restore-cursor": "^3.1.0"
-            }
-        },
-        "cli-width": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-            "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-            "dev": true
         },
         "color-convert": {
             "version": "1.9.3",
@@ -206,12 +239,12 @@
             }
         },
         "debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
             "dev": true,
             "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
             }
         },
         "deep-is": {
@@ -235,6 +268,15 @@
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
         },
+        "enquirer": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^4.1.1"
+            }
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -242,36 +284,37 @@
             "dev": true
         },
         "eslint": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.1.0.tgz",
-            "integrity": "sha512-DfS3b8iHMK5z/YLSme8K5cge168I8j8o1uiVmFCgnnjxZQbCGyraF8bMl7Ju4yfBmCuxD7shOF7eqGkcuIHfsA==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
+            "integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
+                "@eslint/eslintrc": "^0.2.2",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.0.1",
                 "doctrine": "^3.0.0",
-                "eslint-scope": "^5.0.0",
-                "eslint-utils": "^2.0.0",
-                "eslint-visitor-keys": "^1.1.0",
-                "espree": "^7.0.0",
+                "enquirer": "^2.3.5",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^2.1.0",
+                "eslint-visitor-keys": "^2.0.0",
+                "espree": "^7.3.1",
                 "esquery": "^1.2.0",
                 "esutils": "^2.0.2",
-                "file-entry-cache": "^5.0.1",
+                "file-entry-cache": "^6.0.0",
                 "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^5.0.0",
                 "globals": "^12.1.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
-                "inquirer": "^7.0.0",
                 "is-glob": "^4.0.0",
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.14",
+                "lodash": "^4.17.19",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -280,103 +323,61 @@
                 "semver": "^7.2.1",
                 "strip-ansi": "^6.0.0",
                 "strip-json-comments": "^3.1.0",
-                "table": "^5.2.3",
+                "table": "^6.0.4",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/color-name": "^1.1.1",
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-                    "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "7.3.2",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
             }
         },
         "eslint-scope": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-            "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
+                "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
             }
         },
         "eslint-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-            "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
             }
         },
         "eslint-visitor-keys": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-            "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
             "dev": true
         },
         "espree": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-7.0.0.tgz",
-            "integrity": "sha512-/r2XEx5Mw4pgKdyb7GNLQNsu++asx/dltf/CI8RFi9oGHxmQFgvLbc5Op4U6i8Oaj+kdslhJtVlEZeAqH5qOTw==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+            "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
             "dev": true,
             "requires": {
-                "acorn": "^7.1.1",
-                "acorn-jsx": "^5.2.0",
-                "eslint-visitor-keys": "^1.1.0"
+                "acorn": "^7.4.0",
+                "acorn-jsx": "^5.3.1",
+                "eslint-visitor-keys": "^1.3.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
             }
         },
         "esprima": {
@@ -395,20 +396,28 @@
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-                    "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
                     "dev": true
                 }
             }
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
             }
         },
         "estraverse": {
@@ -423,21 +432,10 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
-        "external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
-            "requires": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            }
-        },
         "fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
         "fast-json-stable-stringify": {
@@ -452,39 +450,29 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
-        "figures": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "^1.0.5"
-            }
-        },
         "file-entry-cache": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-            "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
+            "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
             "dev": true,
             "requires": {
-                "flat-cache": "^2.0.1"
+                "flat-cache": "^3.0.4"
             }
         },
         "flat-cache": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
             "dev": true,
             "requires": {
-                "flatted": "^2.0.0",
-                "rimraf": "2.6.3",
-                "write": "1.0.3"
+                "flatted": "^3.1.0",
+                "rimraf": "^3.0.2"
             }
         },
         "flatted": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-            "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
+            "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
             "dev": true
         },
         "fs.realpath": {
@@ -537,15 +525,6 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
-        "iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            }
-        },
         "ignore": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -553,9 +532,9 @@
             "dev": true
         },
         "import-fresh": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-            "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
@@ -583,79 +562,6 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
-        },
-        "inquirer": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-            "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^3.0.0",
-                "cli-cursor": "^3.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^3.0.3",
-                "figures": "^3.0.0",
-                "lodash": "^4.17.15",
-                "mute-stream": "0.0.8",
-                "run-async": "^2.4.0",
-                "rxjs": "^6.5.3",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "through": "^2.3.6"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/color-name": "^1.1.1",
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -691,9 +597,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -723,16 +629,19 @@
             }
         },
         "lodash": {
-            "version": "4.17.19",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+            "version": "4.17.20",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
             "dev": true
         },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "requires": {
+                "yallist": "^4.0.0"
+            }
         },
         "minimatch": {
             "version": "3.0.4",
@@ -743,31 +652,10 @@
                 "brace-expansion": "^1.1.7"
             }
         },
-        "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
-        },
-        "mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5"
-            }
-        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "mute-stream": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
         "natural-compare": {
@@ -783,15 +671,6 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
-            }
-        },
-        "onetime": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-            "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "^2.1.0"
             }
         },
         "open-file-explorer": {
@@ -812,12 +691,6 @@
                 "type-check": "^0.4.0",
                 "word-wrap": "^1.2.3"
             }
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
         },
         "parent-module": {
             "version": "1.0.1",
@@ -864,51 +737,35 @@
             "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
             "dev": true
         },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true
+        },
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
         },
-        "restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dev": true,
-            "requires": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            }
-        },
         "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
         },
-        "run-async": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-            "dev": true
-        },
-        "rxjs": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-            "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+        "semver": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
             "dev": true,
             "requires": {
-                "tslib": "^1.9.0"
+                "lru-cache": "^6.0.0"
             }
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
         },
         "shebang-command": {
             "version": "2.0.0",
@@ -925,27 +782,39 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
-        "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "dev": true
-        },
         "slice-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.0",
-                "astral-regex": "^1.0.0",
-                "is-fullwidth-code-point": "^2.0.0"
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
             },
             "dependencies": {
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 }
             }
@@ -977,9 +846,9 @@
             }
         },
         "strip-json-comments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-            "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
         "supports-color": {
@@ -992,54 +861,34 @@
             }
         },
         "table": {
-            "version": "5.4.6",
-            "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-            "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.0.6.tgz",
+            "integrity": "sha512-OInCtPmDNieVBkVFi6C8RwU2S2H0h8mF3e3TQK4nreaUNCpooQUkI+A/KuEkm5FawfhWIfNqG+qfelVVR+V00g==",
             "dev": true,
             "requires": {
-                "ajv": "^6.10.2",
-                "lodash": "^4.17.14",
-                "slice-ansi": "^2.1.0",
-                "string-width": "^3.0.0"
+                "ajv": "^7.0.2",
+                "lodash": "^4.17.20",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.0"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "emoji-regex": {
+                "ajv": {
                     "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+                    "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
                     "dev": true,
                     "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
                     }
                 },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "dev": true
                 }
             }
         },
@@ -1047,27 +896,6 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
-        },
-        "through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
-        },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "~1.0.2"
-            }
-        },
-        "tslib": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-            "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
             "dev": true
         },
         "type-check": {
@@ -1086,24 +914,24 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-            "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+            "version": "3.9.7",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
             "dev": true
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
             "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
         },
         "v8-compile-cache": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+            "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
             "dev": true
         },
         "which": {
@@ -1127,14 +955,11 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
-        "write": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-            "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-            "dev": true,
-            "requires": {
-                "mkdirp": "^0.5.1"
-            }
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "icon": "images/hypersnips.png",
     "version": "0.1.9",
     "publisher": "draivin",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "https://github.com/draivin/hsnips"
@@ -110,10 +111,10 @@
         "watch": "tsc -watch -p ./"
     },
     "devDependencies": {
-        "@types/node": "^10.14.19",
-        "@types/vscode": "^1.32.0",
-        "eslint": "^7.1.0",
-        "typescript": "^3.9.3"
+        "@types/node": "^10.17.50",
+        "@types/vscode": "^1.52.0",
+        "eslint": "^7.17.0",
+        "typescript": "^3.9.7"
     },
     "dependencies": {
         "open-file-explorer": "^1.0.2"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'fs';
 import * as path from 'path';
-import * as util from 'util';
 import openExplorer = require('open-file-explorer');
 import { HSnippet } from './hsnippet';
 import { HSnippetInstance } from './hsnippetInstance';
@@ -12,26 +11,21 @@ import { getCompletions, CompletionInfo } from './completion';
 const SNIPPETS_BY_LANGUAGE: Map<string, HSnippet[]> = new Map();
 const SNIPPET_STACK: HSnippetInstance[] = [];
 
-const readFileAsync = util.promisify(fs.readFile);
-const readdirAsync = util.promisify(fs.readdir);
-const existsAsync = util.promisify(fs.exists);
-const mkdirAsync = util.promisify(fs.mkdir);
-
 let insertingSnippet = false;
 
 async function loadSnippets() {
   SNIPPETS_BY_LANGUAGE.clear();
 
   let snippetDir = getSnippetDir();
-  if (!(await existsAsync(snippetDir))) {
-    await mkdirAsync(snippetDir);
+  if (!(existsSync(snippetDir))) {
+    mkdirSync(snippetDir);
   }
 
-  for (let file of await readdirAsync(snippetDir)) {
+  for (let file of readdirSync(snippetDir)) {
     if (path.extname(file).toLowerCase() != '.hsnips') continue;
 
     let filePath = path.join(snippetDir, file);
-    let fileData = await readFileAsync(filePath, 'utf8');
+    let fileData = readFileSync(filePath, 'utf8');
 
     let language = path.basename(file, '.hsnips').toLowerCase();
 
@@ -88,7 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('hsnips.openSnippetFile', async () => {
       let snippetDir = getSnippetDir();
-      let files = await readdirAsync(snippetDir);
+      let files = readdirSync(snippetDir);
       let selectedFile = await vscode.window.showQuickPick(files);
 
       if (selectedFile) {

--- a/src/hsnippet.ts
+++ b/src/hsnippet.ts
@@ -1,5 +1,10 @@
 export type GeneratorResult = [(string | { block: number })[], string[]];
-export type GeneratorFunction = (texts: string[], matchGroups: string[]) => GeneratorResult;
+export type GeneratorFunction = (
+  texts: string[],
+  matchGroups: string[],
+  workspaceUri: string,
+  fileUri: string
+) => GeneratorResult;
 
 // Represents a snippet template from which new instances can be created.
 export class HSnippet {

--- a/src/hsnippetInstance.ts
+++ b/src/hsnippetInstance.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { DynamicRange, GrowthType, IChangeInfo } from './dynamicRange';
-import { applyOffset } from './utils';
+import { applyOffset, getWorkspaceUri } from './utils';
 import { HSnippet, GeneratorResult } from './hsnippet';
 
 enum HSnippetPartType {
@@ -61,7 +61,9 @@ export class HSnippetInstance {
     try {
       generatorResult = type.generator(
         new Array(this.type.placeholders).fill(''),
-        this.matchGroups
+        this.matchGroups,
+        getWorkspaceUri(),
+        editor.document.uri.toString()
       );
     } catch (e) {
       vscode.window.showWarningMessage(
@@ -215,7 +217,12 @@ export class HSnippetInstance {
       .filter((p) => p.type == HSnippetPartType.Placeholder)
       .map((p) => p.content);
 
-    let blocks = this.type.generator(placeholderContents, this.matchGroups)[1].map(String);
+    let blocks = this.type.generator(
+      placeholderContents,
+      this.matchGroups,
+      getWorkspaceUri(),
+      this.editor.document.uri.toString()
+    )[1].map(String);
 
     this.editor.edit((edit) => {
       for (let i = 0; i < blocks.length; i++) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -37,7 +37,7 @@ function countPlaceholders(string: string) {
 function parseSnippet(headerLine: string, lines: string[]): IHSnippetInfo {
   let header = parseSnippetHeader(headerLine);
 
-  let script = [`(t, m) => {`];
+  let script = [`(require, t, m) => {`];
   script.push(`let rv = "";`);
   script.push(`let result = [];`);
   script.push(`let blockResults = [];`);
@@ -125,6 +125,10 @@ export function parse(content: string): HSnippet[] {
   }
   script.push(`]`);
 
-  let generators = new Function(script.join('\n'))();
+  let generators = new Function(script.join('\n'))().map((generator: Function) => {
+    // for some reason, `require` is not defined inside the snippet code blocks,
+    // so we're going to bind the it onto the function
+    return generator.bind(null, require) as GeneratorFunction;
+  });
   return snippetInfos.map((s, i) => new HSnippet(s.header, generators[i], s.placeholders));
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -37,7 +37,7 @@ function countPlaceholders(string: string) {
 function parseSnippet(headerLine: string, lines: string[]): IHSnippetInfo {
   let header = parseSnippetHeader(headerLine);
 
-  let script = [`(require, t, m) => {`];
+  let script = [`(require, t, m, w, path) => {`];
   script.push(`let rv = "";`);
   script.push(`let result = [];`);
   script.push(`let blockResults = [];`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,3 +36,7 @@ export function applyOffset(
 
   return position.with(newLine, newChar);
 }
+
+export function getWorkspaceUri(): string {
+  return vscode.workspace.workspaceFolders?.[0]?.uri?.toString() ?? "";
+}


### PR DESCRIPTION
This adds a `require`, `w` and `f` parameter to the snippet generator function.  
The `require` parameter is the usual `require` nodejs function. (because for some reason it wasn't defined in the snippet code blocks)  
`w` and `f` are URI strings for the current workspace and opened document, respectively.

This is related to issue #16. The workspace and file path can now be inserted and be transformed with greater control than what vscode supported previously.

I also updated the dependencies, added the `license` field to the `package.json` and replaced the promisified *Async functions with the official *Sync functions from the `fs` module in the `extnesion.ts` file as well.