### PR TITLE
local workspace snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Or alternatively, you can open this directory by running the command `HyperSnips
 
 Additionally, you can create an `all.hsnips` file for snippets that should be available on all languages.
 
+You can also create a `.vscode/hsnips` folder in your working directory and create your `.hsnips` files there.  
+Snippets declared in `.vscode/hsnips` take precedence over snippets declared in the platform specific folder mentioned above.
+
 ### Snippets file
 
 A snippets file is a file with the `.hsnips` extension, the file is composed of two types of blocks:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or alternatively, you can open this directory by running the command `HyperSnips
 Additionally, you can create an `all.hsnips` file for snippets that should be available on all languages.
 
 You can also create a `.vscode/hsnips` folder in your working directory and create your `.hsnips` files there.  
-Snippets declared in `.vscode/hsnips` take precedence over snippets declared in the platform specific folder mentioned above.
+Snippets declared in `.vscode/hsnips` take precedence over snippets declared in the platform specific folders mentioned above.
 
 ### Snippets file
 


### PR DESCRIPTION
Added the ability to create a `.vscode/hsnips` folder where `.hsnips` files can be placed.
This makes creating project specific snippets more straightforward.

example:
![image](https://user-images.githubusercontent.com/4998293/120529193-82d2b300-c3dc-11eb-8e6c-99a74f011719.png)

Snippets in `.vscode/hsnips` take precedence over snippets in the platform specific folders.
