### PR TITLE
Fix snippets with template literals at the end

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,7 @@
 import { HSnippet, IHSnippetHeader, GeneratorFunction, ContextFilter } from './hsnippet';
 
 const CODE_DELIMITER = '``';
+const CODE_DELIMITER_REGEX = /``(?!`)/
 const HEADER_REGEXP = /^snippet ?(?:`([^`]+)`|(\S+))?(?: "([^"]+)")?(?: ([AMiwb]*))?/;
 
 function parseSnippetHeader(header: string): IHSnippetHeader {
@@ -61,7 +62,7 @@ function parseSnippet(headerLine: string, lines: string[]): IHSnippetInfo {
       if (!line.includes(CODE_DELIMITER)) {
         script.push(line.trim());
       } else {
-        let [code, ...rest] = line.split(CODE_DELIMITER);
+        let [code, ...rest] = line.split(CODE_DELIMITER_REGEX);
         script.push(code.trim());
         lines.unshift(rest.join(CODE_DELIMITER));
         script.push(`_result.push({block: _blockResults.length});`);
@@ -76,7 +77,7 @@ function parseSnippet(headerLine: string, lines: string[]): IHSnippetInfo {
         script.push(`_result.push("\\n");`);
         placeholders += countPlaceholders(line);
       } else if (isCode == false) {
-        let [text, ...rest] = line.split(CODE_DELIMITER);
+        let [text, ...rest] = line.split(CODE_DELIMITER_REGEX);
         script.push(`_result.push("${escapeString(text)}");`);
         script.push(`rv = "";`);
         placeholders += countPlaceholders(text);


### PR DESCRIPTION
This fixes snippets with template literals at the end being parsed wrong.

Example of such a snippet:
```hsnips
snippet `([A-Za-z])(cal|frak|bb)` "Mathcal, frak or bb" iA
``rv = `\\math${m[2]}{${m[1]}}``` 
endsnippet
```

Right now this snippet would break the parser, because the line would be split at the first two backticks, not the last two:
```js
> "``rv = `\\math${m[2]}{${m[1]}}```".split("``")
[ '', 'rv = `\\math${m[2]}{${m[1]}}', '`' ]
```