### PR TITLE
Replace all instances of id when replacing tabstops in rv

### DIFF
--- a/src/hsnippetUtils.ts
+++ b/src/hsnippetUtils.ts
@@ -30,7 +30,7 @@ export class HSnippetUtils {
 
   static format(value: string, utils: HSnippetUtils) {
     for (let [id, text] of utils.placeholders) {
-      value = value.replace(id, text);
+      value = value.replace(new RegExp(`\\[${id.slice(1, -1)}\\]`, 'g'), text);
     }
 
     return value;


### PR DESCRIPTION
Sometimes we may want to reuse the return value of `snip.tabstop()`, such as in `m[0].replace(/@/g, snip.tabstop(1))`. This would cause hsnips to replace only the first instance with a correct tabstop, and leave the second instance as [gibberish]. This commit fixes it.