### PR TITLE
Using global storage to store hsnippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ HyperSnips is a snippet engine for vscode heavily inspired by vim's
 
 To use HyperSnips you create `.hsnips` files on a directory which depends on your platform:
 
-- Windows: `%APPDATA%\Code\User\hsnips\(language).hsnips`
-- Mac: `$HOME/Library/Application Support/Code/User/hsnips/(language).hsnips`
-- Linux: `$HOME/.config/Code/User/hsnips/(language).hsnips`
+- Windows: `%APPDATA%\Code\User\globalStorage\draivin.hsnips\hsnips\(language).hsnips`
+- Mac: `$HOME/Library/Application Support/Code/User/globalStorage/draivin.hsnips/hsnips/(language).hsnips`
+- Linux: `$HOME/.config/Code/User/globalStorage/draivin.hsnips/hsnips/(language).hsnips`
 
 You can open this directory by running the command `HyperSnips: Open snippets directory`.
 This directory may be customized by changing the setting `hsnips.hsnipsPath`.
+If this setting starts with `~` or `${workspaceFolder}`, then it will be replaced with
+your home directory or the current workspace folder, respectively.
 
 The file should be named based on the language the snippets are meant for (e.g. `latex.hsnips`
 for snippets which will be available for LaTeX files).

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,18 +2,128 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 
+export enum SnippetDirType {
+  Global,
+  Workspace,
+}
+
+export interface SnippetDirInfo {
+  readonly type: SnippetDirType;
+  readonly path: string;
+}
+
+/**
+ * "Expanding" here means turning a prefix string like '~' into a string like '/home/foo'
+ */
+const pathPrefixExpanders: {
+  readonly [prefix: string]: {
+    readonly finalPathType: SnippetDirType;
+    readonly prefixExpanderFunc: () => string | null;
+  };
+} = {
+  '~': ({ finalPathType: SnippetDirType.Global, prefixExpanderFunc: os.homedir, }),
+  '${workspaceFolder}': ({ finalPathType: SnippetDirType.Workspace, prefixExpanderFunc: getWorkspaceFolderPath, }),
+};
+
+function getWorkspaceFolderPath(): string | null {
+  return vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath || null;
+}
+
 export function lineRange(character: number, position: vscode.Position): vscode.Range {
   return new vscode.Range(position.line, character, position.line, position.character);
 }
 
-export function getSnippetDir(): string {
+/**
+ * The parameter `options`, can be removed after the function `getOldGlobalSnippetDir` is removed and migration from the
+ * directory to the new one is not necessary anymore.
+ */
+export function getSnippetDirInfo(
+  context: vscode.ExtensionContext,
+  options: { ignoreWorkspace: boolean } = { ignoreWorkspace: false },
+): SnippetDirInfo {
   let hsnipsPath = vscode.workspace.getConfiguration('hsnips').get('hsnipsPath') as string | null;
 
-  if (hsnipsPath) {
-    let workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  // only non-empty strings are taken, anything else is discarded
+  if (typeof hsnipsPath === 'string' && hsnipsPath.length > 0) {
+    // normalize to ensure that the correct platform-specific file separators are used
+    hsnipsPath = path.normalize(hsnipsPath);
 
-    if (path.isAbsolute(hsnipsPath)) return hsnipsPath;
-    else if (workspaceFolder) return path.join(workspaceFolder.uri.fsPath, hsnipsPath);
+    let type: SnippetDirType | null = null;
+
+    // first some "preprocessing" is done on the configured path: expanding leading '~' and '${workspaceFolder}'
+    for (const prefix in pathPrefixExpanders) {
+      // a leading string like '~foo' is ignored, only '~' or '~/foo' values are taken
+      if (hsnipsPath !== prefix && !hsnipsPath.startsWith(prefix + path.sep)) {
+        continue;
+      }
+
+      const expandingInfo = pathPrefixExpanders[prefix];
+
+      if (options.ignoreWorkspace && expandingInfo.finalPathType == SnippetDirType.Workspace) {
+        // this expander would've resulted in a workspace folder path; skip it
+        continue;
+      }
+
+      const expandedPrefix = expandingInfo.prefixExpanderFunc();
+
+      if (expandedPrefix) {
+        hsnipsPath = expandedPrefix + hsnipsPath.substring(prefix.length);
+        type = expandingInfo.finalPathType;
+      } else {
+        // in case the prefix did match, but the expanded function wasn't able to properly expand, the entire path will
+        // be invalidated
+        // e.g.: given the string '~/foo', but the home directory could not be determined for some reason
+        hsnipsPath = null;
+        type = null;
+      }
+
+      break;
+    }
+
+    // this will only be falsy if the path was invalidated as a result of one of the expander functions failing to
+    // properly expanding a prefix
+    if (hsnipsPath) {
+      if (!options.ignoreWorkspace) {
+        const workspaceFolderPath = getWorkspaceFolderPath();
+        if (!path.isAbsolute(hsnipsPath) && workspaceFolderPath) {
+          hsnipsPath = path.join(workspaceFolderPath, hsnipsPath);
+          type = SnippetDirType.Workspace;
+        }
+      }
+
+      // at this point the path will only be relative in four cases:
+      //  * an already relative path was configured without a matching prefix to expand
+      //  * one of the expander functions messed up and returned a relative path
+      //  * the function `getWorkspaceFolderPath` messed and returned a relative path
+      //  * the path would've been a workspace path, but the parameter `ignoreWorkspace` is set to `true`
+      if (path.isAbsolute(hsnipsPath)) {
+        if (type === null) {
+          type = SnippetDirType.Global;
+        }
+
+        return {
+          type,
+          path: hsnipsPath,
+        };
+      }
+    }
+  }
+
+  const globalStoragePath = context.globalStorageUri.fsPath;
+  return {
+    type: SnippetDirType.Global,
+    path: path.join(globalStoragePath, 'hsnips'),
+  };
+}
+
+/**
+ * @deprecated The paths here are hardcoded in. Only keep this function so that older users can migrate.
+ */
+export function getOldGlobalSnippetDir(): string {
+  let hsnipsPath = vscode.workspace.getConfiguration('hsnips').get('hsnipsPath') as string | null;
+
+  if (hsnipsPath && path.isAbsolute(hsnipsPath)) {
+    return hsnipsPath;
   }
 
   let platform = os.platform();


### PR DESCRIPTION
This PR changes the directory where the hsnippet files are stored from the hardcoded directory to use the [globalStorage](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext.globalStorageUri) directory instead.

To help updating users migrate, if the old directory exists, it will be moved into the new globalStorage directory.

This change should fix issue #131.

How the `"hsnips.hsnipsPath"` configuration is interpreted also changed.
If the path starts with `"~"` or `"${workspaceFolder}"` then it is replaced with the user's home directory or the workspace folder, respectively.  
Relative paths will still be joined with the workspace folder, to keep backwards compatibility.
